### PR TITLE
HD-896: JDBC connection to Kerberized Hive

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1017,6 +1017,14 @@ public class HiveConf extends Configuration {
     HIVE_COMPAT("hive.compat", HiveCompat.DEFAULT_COMPAT_LEVEL),
     HIVE_CONVERT_JOIN_BUCKET_MAPJOIN_TEZ("hive.convert.join.bucket.mapjoin.tez", false),
 
+    // ALTISCALE: add new configuration for SASL(PLAIN) over SSL on kerberos
+    HIVE_SERVER2_THRIFT_KERBEROS_USE_SSL("hive.server2.thrift.kerberos.use.SSL", false),
+    HIVE_SERVER2_THRIFT_KERBEROS_SSL_PORT("hive.server2.thrift.kerberos.ssl.port", 10010),
+    HIVE_SERVER2_THRIFT_KERBEROS_SSL_KEYSTORE_PATH("hive.server2.thrift.kerberos.ssl.keystore.path", ""),
+    HIVE_SERVER2_THRIFT_KERBEROS_SSL_KEYSTORE_PASSWORD("hive.server2.thrift.kerberos.ssl.keystore.password", ""),
+    HIVE_SERVER2_THRIFT_KERBEROS_SSL_MIN_WORKER_THREADS("hive.server2.thrift.kerberos.ssl.min.worker.threads", 5),
+    HIVE_SERVER2_THRIFT_KERBEROS_SSL_MAX_WORKER_THREADS("hive.server2.thrift.kerberos.ssl.max.worker.threads", 500),
+
     // Check if a plan contains a Cross Product.
     // If there is one, output a warning to the Session's console.
     HIVE_CHECK_CROSS_PRODUCT("hive.exec.check.crossproducts", true),

--- a/service/src/java/org/apache/hive/service/auth/HiveAuthFactory.java
+++ b/service/src/java/org/apache/hive/service/auth/HiveAuthFactory.java
@@ -139,6 +139,20 @@ public class HiveAuthFactory {
     return transportFactory;
   }
 
+  public TTransportFactory getAuthPlainTransFactory() throws LoginException {
+    TTransportFactory transportFactory;
+    if (authTypeStr.equalsIgnoreCase(AuthTypes.KERBEROS.getAuthName())) {
+      try {
+        transportFactory = saslServer.createPlainTransportFactory(getSaslProperties());
+      } catch (TTransportException e) {
+        throw new LoginException(e.getMessage());
+      }
+    } else {
+      throw new LoginException("Unsupported authentication type " + authTypeStr);
+    }
+    return transportFactory;
+  }
+
   public TProcessorFactory getAuthProcFactory(ThriftCLIService service)
       throws LoginException {
     if (transportMode.equalsIgnoreCase("http")) {

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
@@ -20,20 +20,33 @@ package org.apache.hive.service.cli.thrift;
 
 import java.net.InetSocketAddress;
 
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hive.service.auth.HiveAuthFactory;
 import org.apache.hive.service.cli.CLIService;
 import org.apache.thrift.TProcessorFactory;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.server.TServer;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransportFactory;
 
 
 public class ThriftBinaryCLIService extends ThriftCLIService {
 
+  TServer plainSSLserver;
+
   public ThriftBinaryCLIService(CLIService cliService) {
     super(cliService, "ThriftBinaryCLIService");
+  }
+
+  @Override
+  public synchronized void stop() {
+    if (plainSSLserver != null) {
+      plainSSLserver.stop();
+      LOG.info("Thrift SASL(PLAIN) over SSL server has stopped");
+    }
+    super.stop();
   }
 
   @Override
@@ -87,11 +100,90 @@ public class ThriftBinaryCLIService extends ThriftCLIService {
 
       LOG.info("ThriftBinaryCLIService listening on " + serverAddress);
 
+      // ALTISCALE - new thread : SASL(PALIN) over SSL thread for custom class
+      String transportMode = hiveConf.getVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE);
+      String authTypeStr = hiveConf.getVar(ConfVars.HIVE_SERVER2_AUTHENTICATION);
+      final ThriftCLIService svc = this;
+      final String hiveServerHost = hiveHost;
+
+      if (!transportMode.equalsIgnoreCase("http")
+          && authTypeStr.equalsIgnoreCase(HiveAuthFactory.AuthTypes.KERBEROS.toString())
+          && hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_THRIFT_KERBEROS_USE_SSL)) {
+        Thread t = new Thread() {
+          @Override
+          public void run() {
+            try {
+              startPlainSSLOnKerberos(hiveConf,
+                svc, hiveServerHost, plainSSLserver);
+            } catch (Throwable t) {
+              LOG.error("Failure ThriftBinaryCLIService SASL(PLAIN) over SSL listening on kerberos " + serverAddress + ": " + t.getMessage());
+            }
+          }
+        };
+        t.start();
+      }
+
       server.serve();
 
     } catch (Throwable t) {
       LOG.error("Error: ", t);
     }
 
+  }
+
+  // ALTISCALE - SASL(PALIN) over SSL thread for custom class
+  private static void startPlainSSLOnKerberos(
+    HiveConf hiveConf,
+    final ThriftCLIService service,
+    final String hiveHost,
+    TServer plainSSLserver) throws Exception {
+
+    try {
+      int sslPortNum;
+      String portString = System.getenv("HIVE_SERVER2_THRIFT_KERBEROS_SSL_PORT");
+      if (portString != null) {
+        sslPortNum = Integer.valueOf(portString);
+      } else {
+        sslPortNum = hiveConf.getIntVar(ConfVars.HIVE_SERVER2_THRIFT_KERBEROS_SSL_PORT);
+      }
+
+      InetSocketAddress serverAddress;
+      if (hiveHost != null && !hiveHost.isEmpty()) {
+        serverAddress = new InetSocketAddress(hiveHost, sslPortNum);
+      } else {
+        serverAddress = new InetSocketAddress(sslPortNum);
+      }
+
+      int minWorkerThreads = hiveConf.getIntVar(ConfVars.HIVE_SERVER2_THRIFT_KERBEROS_SSL_MIN_WORKER_THREADS);
+      int maxWorkerThreads = hiveConf.getIntVar(ConfVars.HIVE_SERVER2_THRIFT_KERBEROS_SSL_MAX_WORKER_THREADS);
+
+      HiveAuthFactory hiveAuthFactory = new HiveAuthFactory();
+      TTransportFactory transportFactory = hiveAuthFactory.getAuthPlainTransFactory();
+      TProcessorFactory processorFactory = hiveAuthFactory.getAuthProcFactory(service);
+
+      TServerSocket plainSSLSocket = null;
+      String keyStorePath = hiveConf.getVar(ConfVars.HIVE_SERVER2_THRIFT_KERBEROS_SSL_KEYSTORE_PATH).trim();
+      if (keyStorePath.isEmpty()) {
+        throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_THRIFT_KERBEROS_SSL_KEYSTORE_PATH.varname +
+        " Not configured for SSL connection");
+      }
+      plainSSLSocket = HiveAuthFactory.getServerSSLSocket(hiveHost, sslPortNum,
+        keyStorePath, hiveConf.getVar(ConfVars.HIVE_SERVER2_THRIFT_KERBEROS_SSL_KEYSTORE_PASSWORD));
+
+      TThreadPoolServer.Args sargs = new TThreadPoolServer.Args(plainSSLSocket)
+      .processorFactory(processorFactory)
+      .transportFactory(transportFactory)
+      .protocolFactory(new TBinaryProtocol.Factory())
+      .minWorkerThreads(minWorkerThreads)
+      .maxWorkerThreads(maxWorkerThreads);
+
+      plainSSLserver = new TThreadPoolServer(sargs);
+
+      LOG.info("ThriftBinaryCLIService SASL(PLAIN) over SSL on Kerberos listening on " + serverAddress);
+
+      plainSSLserver.serve();
+    } catch (Throwable t) {
+      LOG.error("Error: ", t);
+    }
   }
 }

--- a/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/CustomAuthenticationProvider.java
+++ b/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/CustomAuthenticationProvider.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.hive.thrift;
+
+import javax.security.sasl.AuthenticationException;
+
+public interface CustomAuthenticationProvider {
+ /**
+  * The Authenticate method is called by the thrift (HiveServer2, HiveMetastore) authentication layer
+  * to authenticate users for their requests (Server side).
+  * It has the same pattern with PasswordAuthenticationProvider.
+  * If a user is to be granted, return nothing/throw nothing.
+  * When a user is to be disallowed, throw an appropriate {@link AuthenticationException}.
+  *
+  * For an example implementation, see {@link LdapAuthenticationProviderImpl}.
+  *
+  * @param user - The username received over the connection request
+  * @param password - The password received over the connection request
+  * @throws AuthenticationException - When a user is found to be
+  * invalid by the implementation
+  */
+  void Authenticate(String user, String password) throws AuthenticationException;
+}

--- a/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/DefaultCustomAuthenticationProviderImpl.java
+++ b/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/DefaultCustomAuthenticationProviderImpl.java
@@ -1,0 +1,16 @@
+package org.apache.hadoop.hive.thrift;
+
+import javax.security.sasl.AuthenticationException;
+
+public class DefaultCustomAuthenticationProviderImpl implements CustomAuthenticationProvider {
+
+ /**
+  * This class will be called when hive.server2.authentication=KERBEROS without setup custom class.
+  * As a result, we will not support PLAIN mechanism on kerberized cluster
+  * except when hive.server2.thrift.custom.authentication.class=<class name> on hite-site.xml
+  **/
+  @Override
+  public void Authenticate(String user, String password) throws AuthenticationException {
+    throw new AuthenticationException("Unsupported authentication method on Kerberos environment");
+  }
+}

--- a/shims/common/src/main/java/org/apache/hadoop/hive/thrift/HadoopThriftAuthBridge.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/thrift/HadoopThriftAuthBridge.java
@@ -100,6 +100,7 @@ public class HadoopThriftAuthBridge {
 
   public static abstract class Server {
     public abstract TTransportFactory createTransportFactory(Map<String, String> saslProps) throws TTransportException;
+    public abstract TTransportFactory createPlainTransportFactory(Map<String, String> saslProps) throws TTransportException;
     public abstract TProcessor wrapProcessor(TProcessor processor);
     public abstract TProcessor wrapNonAssumingProcessor(TProcessor processor);
     public abstract InetAddress getRemoteAddress();


### PR DESCRIPTION
1. Use delegationToken string
   1) It extends dtToken parameter on JDBC connection (dtToken)
   2) ex) jdbc:hive2://sookim-test-cluster-services.test.altiscale.com:10000/;auth=delegationToken;dtToken=XXXXXXXXX
   3) cons: Client should use Altiscale's org.apache.hive.jdbc.HiveDriver
2. Use custom class
   1) On the kerberized cluster, hiveserver2 listens PLAIN over SSL port.
   2) Client connects the hiveserver2 on JDBC connection with user_id and user_password.
   3) Hiveserver2 verifies the user_id and user_password using custom class.
