### PR TITLE
HD-1283: Patch for HIVE-10292 on Hive-0.13.

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1017,6 +1017,15 @@ public class HiveConf extends Configuration {
     HIVE_COMPAT("hive.compat", HiveCompat.DEFAULT_COMPAT_LEVEL),
     HIVE_CONVERT_JOIN_BUCKET_MAPJOIN_TEZ("hive.convert.join.bucket.mapjoin.tez", false),
 
+    // kerberos custom class
+    HIVE_SERVER2_KERBEROS_USE_SSL("hive.server2.kerberos.use.SSL", false),
+    HIVE_SERVER2_KERBEROS_SSL_PORT("hive.server2.kerberos.ssl.port", 10010),
+    HIVE_SERVER2_KERBEROS_SSL_KEYSTORE_PATH("hive.server2.kerberos.ssl.keystore.path", ""),
+    HIVE_SERVER2_KERBEROS_SSL_KEYSTORE_PASSWORD("hive.server2.kerberos.ssl.keystore.password", ""),
+    HIVE_SERVER2_KERBEROS_SSL_MIN_WORKER_THREADS("hive.server2.kerberos.ssl.min.worker.threads", 5),
+    HIVE_SERVER2_KERBEROS_SSL_MAX_WORKER_THREADS("hive.server2.kerberos.ssl.max.worker.threads", 500),
+    HIVE_SERVER2_KERBEROS_SSL_CUSTOM_AUTHENTICATION_CLASS("hive.server2.kerberos.ssl.custom.authentication.class", null),
+
     // Check if a plan contains a Cross Product.
     // If there is one, output a warning to the Session's console.
     HIVE_CHECK_CROSS_PRODUCT("hive.exec.check.crossproducts", true),

--- a/service/src/java/org/apache/hive/service/auth/HiveAuthFactory.java
+++ b/service/src/java/org/apache/hive/service/auth/HiveAuthFactory.java
@@ -139,6 +139,26 @@ public class HiveAuthFactory {
     return transportFactory;
   }
 
+  /**
+   * Returns an authentication factory for HiveServer2 running
+   * that verifies the ID/PASSWORD using custom class over SSL with Kerberos
+   * @return
+   * @throws LoginException
+   */
+  public TTransportFactory getAuthPlainTransFactory() throws LoginException {
+    TTransportFactory transportFactory;
+    if (authTypeStr.equalsIgnoreCase(AuthTypes.KERBEROS.getAuthName())) {
+      try {
+        transportFactory = saslServer.createPlainTransportFactory(getSaslProperties());
+      } catch (TTransportException e) {
+        throw new LoginException(e.getMessage());
+      }
+    } else {
+      throw new LoginException("Unsupported authentication type " + authTypeStr);
+    }
+    return transportFactory;
+  }
+
   public TProcessorFactory getAuthProcFactory(ThriftCLIService service)
       throws LoginException {
     if (transportMode.equalsIgnoreCase("http")) {

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
@@ -20,20 +20,32 @@ package org.apache.hive.service.cli.thrift;
 
 import java.net.InetSocketAddress;
 
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hive.service.auth.HiveAuthFactory;
 import org.apache.hive.service.cli.CLIService;
 import org.apache.thrift.TProcessorFactory;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.server.TServer;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransportFactory;
 
 
 public class ThriftBinaryCLIService extends ThriftCLIService {
+  TServer sslWithKrbServer;
 
   public ThriftBinaryCLIService(CLIService cliService) {
     super(cliService, "ThriftBinaryCLIService");
+  }
+
+  @Override
+  public synchronized void stop() {
+    if (sslWithKrbServer != null) {
+        sslWithKrbServer.stop();
+      LOG.info("Thrift SASL(PLAIN) over SSL with Kerberos server has stopped");
+    }
+    super.stop();
   }
 
   @Override
@@ -87,11 +99,90 @@ public class ThriftBinaryCLIService extends ThriftCLIService {
 
       LOG.info("ThriftBinaryCLIService listening on " + serverAddress);
 
+      // New thread : SASL(PLAIN) over SSL with Kerberos thread for custom class
+      final ThriftCLIService svc = this;
+      final String hiveServerHost = hiveHost;
+      String transportMode = hiveConf.getVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE);
+      String authTypeStr = hiveConf.getVar(ConfVars.HIVE_SERVER2_AUTHENTICATION);
+
+      if (!transportMode.equalsIgnoreCase("http")
+          && authTypeStr.equalsIgnoreCase(HiveAuthFactory.AuthTypes.KERBEROS.toString())
+          && hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_KERBEROS_USE_SSL)) {
+        Thread t = new Thread() {
+          @Override
+          public void run() {
+            try {
+              startPlainSSLWithKerberos(hiveConf,
+                svc, hiveServerHost, sslWithKrbServer);
+            } catch (Throwable t) {
+              LOG.error(
+                "Failure ThriftBinaryCLIService SASL over SSL with Kerberos listening on "
+                + hiveServerHost + ": " + t.getMessage());
+            }
+          }
+        };
+        t.start();
+      }
+
       server.serve();
 
     } catch (Throwable t) {
       LOG.error("Error: ", t);
     }
+  }
 
+  // SASL(PLAIN) over SSL with Kerberos thread for custom class
+  private static void startPlainSSLWithKerberos(
+    final HiveConf hiveConf,
+    final ThriftCLIService service,
+    final String hiveHost,
+    TServer sslWithKrbServer) throws Exception {
+
+    try {
+      int minWorkerThreads = hiveConf.getIntVar(ConfVars.HIVE_SERVER2_KERBEROS_SSL_MIN_WORKER_THREADS);
+      int maxWorkerThreads = hiveConf.getIntVar(ConfVars.HIVE_SERVER2_KERBEROS_SSL_MAX_WORKER_THREADS);
+
+      int sslPortNum;
+      String portString = System.getenv("HIVE_SERVER2_KERBEROS_SSL_PORT");
+      if (portString != null) {
+        sslPortNum = Integer.valueOf(portString);
+      } else {
+        sslPortNum = hiveConf.getIntVar(ConfVars.HIVE_SERVER2_KERBEROS_SSL_PORT);
+      }
+
+      // SASL over SSL with Kerberos configs
+      HiveAuthFactory hiveAuthFactory = new HiveAuthFactory();
+      TTransportFactory transportFactory = hiveAuthFactory.getAuthPlainTransFactory();
+      TProcessorFactory processorFactory = hiveAuthFactory.getAuthProcFactory(service);
+      TServerSocket sslWithKrbSocket = null;
+
+      String keyStorePath = hiveConf.getVar(ConfVars.HIVE_SERVER2_KERBEROS_SSL_KEYSTORE_PATH).trim();
+      if (keyStorePath.isEmpty()) {
+        throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_KERBEROS_SSL_KEYSTORE_PATH.varname +
+        " Not configured for SSL connection");
+      }
+      String keyStorePassword = hiveConf.getVar(ConfVars.HIVE_SERVER2_KERBEROS_SSL_KEYSTORE_PASSWORD);
+      sslWithKrbSocket = HiveAuthFactory.getServerSSLSocket(hiveHost, sslPortNum,
+        keyStorePath, keyStorePassword);
+
+      // Server args
+      TThreadPoolServer.Args sargs = new TThreadPoolServer.Args(sslWithKrbSocket)
+         .processorFactory(processorFactory).transportFactory(transportFactory)
+         .protocolFactory(new TBinaryProtocol.Factory())
+         .minWorkerThreads(minWorkerThreads)
+         .maxWorkerThreads(maxWorkerThreads);
+
+      // TCP Server
+      sslWithKrbServer = new TThreadPoolServer(sargs);
+      String msg = "Starting " + ThriftBinaryCLIService.class.getSimpleName()
+         + " SASL over SSL with Kerberos listening on "
+         + sslPortNum + " with " + minWorkerThreads + "..." + maxWorkerThreads + " worker threads";
+      LOG.info(msg);
+
+      sslWithKrbServer.serve();
+    } catch (Throwable t) {
+      LOG.error(
+        "Error starting HiveServer2: could not start SSL with Kerberos", t);
+    }
   }
 }

--- a/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/DefaultKrbCustomAuthenticationProviderImpl.java
+++ b/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/DefaultKrbCustomAuthenticationProviderImpl.java
@@ -1,0 +1,16 @@
+package org.apache.hadoop.hive.thrift;
+
+import javax.security.sasl.AuthenticationException;
+
+public class DefaultKrbCustomAuthenticationProviderImpl implements KrbCustomAuthenticationProvider {
+
+  /**
+   * This class will be called when you set 
+   * hive.server2.authentication=KERBEROS and hive.server2.kerberos.use.SSL = true 
+   * with hive.server2.kerberos.ssl.custom.authentication.class=<class name> on hive-site.xml
+   **/
+  @Override
+  public void Authenticate(String user, String password) throws AuthenticationException {
+    throw new AuthenticationException("Unsupported authentication method on Kerberos environment");
+  }
+}

--- a/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/KrbCustomAuthenticationProvider.java
+++ b/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/KrbCustomAuthenticationProvider.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.hive.thrift;
+
+import javax.security.sasl.AuthenticationException;
+
+public interface KrbCustomAuthenticationProvider {
+ /**
+  * The Authenticate method is called by the thrift (HiveServer2, HiveMetastore) authentication layer
+  * to authenticate users for their requests (Server side).
+  * It has the same pattern with PasswdAuthenticationProvider.
+  * If a user is to be granted, return nothing/throw nothing.
+  * When a user is to be disallowed, throw an appropriate {@link AuthenticationException}.
+  *
+  * For an example implementation, see {@link LdapAuthenticationProviderImpl}.
+  *
+  * @param user - The username received over the connection request
+  * @param password - The password received over the connection request
+  * @throws AuthenticationException - When a user is found to be
+  * invalid by the implementation
+  */
+  void Authenticate(String user, String password) throws AuthenticationException;
+}

--- a/shims/common/src/main/java/org/apache/hadoop/hive/thrift/HadoopThriftAuthBridge.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/thrift/HadoopThriftAuthBridge.java
@@ -100,6 +100,7 @@ public class HadoopThriftAuthBridge {
 
   public static abstract class Server {
     public abstract TTransportFactory createTransportFactory(Map<String, String> saslProps) throws TTransportException;
+    public abstract TTransportFactory createPlainTransportFactory(Map<String, String> saslProps) throws TTransportException;
     public abstract TProcessor wrapProcessor(TProcessor processor);
     public abstract TProcessor wrapNonAssumingProcessor(TProcessor processor);
     public abstract InetAddress getRemoteAddress();


### PR DESCRIPTION
It supports authentication custom class with Kerberos through Hive JDBC/ODBC.
The additional parameters in hive-site.xml as following:
. hive.server2.kerberos.use.SSL=true (default)
. hive.server2.kerberos.ssl.port=10010 (default)
. hive.server2.kerberos.ssl.min.worker.threads=5 (default)
. hive.server2.kerberos.ssl.max.worker.threads=500 (default)
. hive.server2.kerberos.ssl.keystore.path = [ssl keystore filename]
. hive.server2.kerberos.ssl.keystore.password = [password for keystore decryption]
. hive.server2.kerberos.ssl.custom.authentication.class=[custom_auth_class]
