### PR TITLE
HD-1283: Support custom authentication class with kerberos

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1018,13 +1018,14 @@ public class HiveConf extends Configuration {
     HIVE_CONVERT_JOIN_BUCKET_MAPJOIN_TEZ("hive.convert.join.bucket.mapjoin.tez", false),
 
     // kerberos custom class
-    HIVE_SERVER2_KERBEROS_USE_SSL("hive.server2.kerberos.use.SSL", false),
-    HIVE_SERVER2_KERBEROS_SSL_PORT("hive.server2.kerberos.ssl.port", 10010),
-    HIVE_SERVER2_KERBEROS_SSL_KEYSTORE_PATH("hive.server2.kerberos.ssl.keystore.path", ""),
-    HIVE_SERVER2_KERBEROS_SSL_KEYSTORE_PASSWORD("hive.server2.kerberos.ssl.keystore.password", ""),
-    HIVE_SERVER2_KERBEROS_SSL_MIN_WORKER_THREADS("hive.server2.kerberos.ssl.min.worker.threads", 5),
-    HIVE_SERVER2_KERBEROS_SSL_MAX_WORKER_THREADS("hive.server2.kerberos.ssl.max.worker.threads", 500),
-    HIVE_SERVER2_KERBEROS_SSL_CUSTOM_AUTHENTICATION_CLASS("hive.server2.kerberos.ssl.custom.authentication.class", null),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_USED("hive.server2.kerberos.custom.authentication.used", false),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS("hive.server2.kerberos.custom.authentication.class", null),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_PORT("hive.server2.kerberos.custom.authentication.port", 10010),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_MIN_WORKER_THREADS("hive.server2.kerberos.custom.authentication.min.worker.threads", 5),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_MAX_WORKER_THREADS("hive.server2.kerberos.custom.authentication.max.worker.threads", 500),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_USED("hive.server2.kerberos.custom.authentication.SSL.used", false),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PATH("hive.server2.kerberos.custom.authentication.ssl.keystore.path", ""),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PASSWORD("hive.server2.kerberos.custom.authentication.ssl.keystore.password", ""),
 
     // Check if a plan contains a Cross Product.
     // If there is one, output a warning to the Session's console.

--- a/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/DefaultKrbCustomAuthenticationProviderImpl.java
+++ b/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/DefaultKrbCustomAuthenticationProviderImpl.java
@@ -6,8 +6,8 @@ public class DefaultKrbCustomAuthenticationProviderImpl implements KrbCustomAuth
 
   /**
    * This class will be called when you set 
-   * hive.server2.authentication=KERBEROS and hive.server2.kerberos.use.SSL = true 
-   * with hive.server2.kerberos.ssl.custom.authentication.class=<class name> on hive-site.xml
+   * hive.server2.authentication=KERBEROS and hive.server2.kerberos.custom.authentication.used = true
+   * with hive.server2.kerberos.custom.authentication.class=<class name> on hive-site.xml
    **/
   @Override
   public void Authenticate(String user, String password) throws AuthenticationException {

--- a/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/HadoopThriftAuthBridge20S.java
+++ b/shims/common-secure/src/main/java/org/apache/hadoop/hive/thrift/HadoopThriftAuthBridge20S.java
@@ -273,8 +273,8 @@ public class HadoopThriftAuthBridge20S extends HadoopThriftAuthBridge {
         "hive.cluster.delegation.token.store.zookeeper.acl";
     public static final String DELEGATION_TOKEN_STORE_ZK_ZNODE_DEFAULT =
         "/hive/cluster/delegation";
-    public static final String HIVE_SERVER2_KERBEROS_SSL_CUSTOM_AUTHENTICATION_CLASS =
-        "hive.server2.kerberos.ssl.custom.authentication.class";
+    public static final String HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS =
+        "hive.server2.kerberos.custom.authentication.class";
 
     public Server() throws TTransportException {
       try {
@@ -518,16 +518,16 @@ public class HadoopThriftAuthBridge20S extends HadoopThriftAuthBridge {
       return remoteUser.get();
     }
 
-    /** CallbackHandler for Server Custom class over SSL with Kerberos */
+    /** CallbackHandler for Server Custom authentication class with Kerberos */
     // The client mechanism uses PLAIN on SASL API with Kerberos.
     // Therefore, it has the similar format with PlainServerCallbackHandler.
     static class SaslCustomServerCallbackHandler implements CallbackHandler {
       private KrbCustomAuthenticationProvider customProvider;
 
       public SaslCustomServerCallbackHandler(Configuration conf) {
-        // Default custom class : It only allows CUSTOM authentication over SSL with Kerberos cluster
+        // Default custom class : It only allows CUSTOM authentication with Kerberos cluster
         String customClassName = conf.get(
-          HIVE_SERVER2_KERBEROS_SSL_CUSTOM_AUTHENTICATION_CLASS,
+          HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS,
           "org.apache.hadoop.hive.thrift.DefaultKrbCustomAuthenticationProviderImpl");
 
         try {


### PR DESCRIPTION
Our requirement is changed.
1. Support the custom authentication class with kerberos.
. hive.server2.kerberos.custom.authentication.used=true/false
2. If the custom authentication class is true, the customer can select the connection type (over SSL or without SSL).
. hive.server2.kerberos.custom.authentication.SSL.used=true/false
